### PR TITLE
Rollback Platform to 0.86

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.proofpoint.platform</groupId>
         <artifactId>rest-server-base</artifactId>
-        <version>0.87</version>
+        <version>0.86</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
The JAX-RS Pulse monitoring feature mishandles resource methods that have the same name.
